### PR TITLE
Preserve empty nodes to prevent tikz errors

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -129,7 +129,7 @@ export class Diagram extends Component {
             this.toArray().map(entries => entries.map(entry =>
                 entry == null ? ''
                 : [
-                    entry.node.attributes.value,
+                    entry.node.attributes.value || '{}',
                     ...entry.edges.map(e => renderEdge(e, this.props.co))
                 ].join(' ')
             ).join(' & ')).join(' \\\\\n'),


### PR DESCRIPTION
Empty nodes (specifically those representing endpoints of arrows that do not have an explicit target) can be semantically important — *tikzcd* requires arrows to have targets, even if they are empty nodes (`{}`). At the moment, empty nodes have no content in the outputted *tikzcd* diagram, which can cause incorrect diagram code resulting in *tikz* errors.

This issue affects https://github.com/yishn/tikzcd-editor/, especially for the use case of drawing arrows between arrows.