### PR TITLE
Add vertical alignment to diagram renderer

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -125,23 +125,34 @@ export class Diagram extends Component {
     render() {
         let options = this.props.options == null ? '' : `[${this.props.options}]`
 
+        let cells = this.toArray().map(entries => entries.map(entry =>
+            entry == null ? ''
+            : [
+                (() => {
+                    let value = entry.node.props.value
+                    let [w1, w2] = value != null
+                        && needWrapChars.some(c => value.includes(c))
+                        ? ['{', '}'] : ['', '']
+
+                    return value != null ? `${w1}${value}${w2}` : '{}'
+                })(),
+                ...entry.edges.map(e => renderEdge(e, this.props.co))
+            ].join(' ')
+        ))
+
+        if (this.props.align && cells.length > 0) {
+            for (let j = 0; j < cells[0].length; j++) {
+                let maxLength = Math.max(...cells.map(entries => entries[j].length))
+                for (let i = 0; i < cells.length; i++) {
+                    cells[i][j] = cells[i][j].padEnd(maxLength, ' ')
+                }
+            }
+        }
+
         return [
             `\\begin{tikzcd}${options}`,
 
-            this.toArray().map(entries => entries.map(entry =>
-                entry == null ? ''
-                : [
-                    (() => {
-                        let value = entry.node.props.value;
-                        let [w1, w2] = value != null
-                            && needWrapChars.some(c => value.includes(c))
-                            ? ['{', '}'] : ['', '']
-
-                        return value != null ? `${w1}${value}${w2}` : '{}'
-                    })(),
-                    ...entry.edges.map(e => renderEdge(e, this.props.co))
-                ].join(' ')
-            ).join(' & ')).join(' \\\\\n'),
+            cells.map(entries => entries.join(' & ')).join(' \\\\\n'),
 
             '\\end{tikzcd}'
         ].join('\n')

--- a/src/render.js
+++ b/src/render.js
@@ -19,7 +19,7 @@ function resolveComponents(vnode) {
     }
 }
 
-export function renderToDiagram(vnode, co = false) {
+export function renderToDiagram(vnode, options = {}, co = false) {
     let diagramNode = resolveComponents(vnode)
 
     if (diagramNode == null || diagramNode.type !== Diagram)
@@ -28,14 +28,15 @@ export function renderToDiagram(vnode, co = false) {
     return new Diagram({
         ...diagramNode.props,
         co: co !== !!diagramNode.props.co,
+        align: options.align ? options.align : false,
         children: diagramNode.children
     })
 }
 
-export function render(vnode, co = false) {
-    return renderToDiagram(vnode, co).render()
+export function render(vnode, options = {}, co = false) {
+    return renderToDiagram(vnode, options, co).render()
 }
 
-export function corender(vnode) {
-    return render(vnode, true)
+export function corender(vnode, options = {}) {
+    return render(vnode, options, true)
 }


### PR DESCRIPTION
This is optional and off by default.

I have not implemented an options object for `render()` as suggested in  https://github.com/yishn/tikzcd-editor/issues/27#issuecomment-425070268 since I was not sure how to deal with the existing `co` option in this case.