### PR TITLE
Correct \arrow syntax for directionless arrows

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -22,7 +22,7 @@ function renderEdge(vnode, co = false) {
         && needWrapChars.some(c => value.includes(c))
         ? ['{', '}'] : ['', '']
     let valueArg = value != null ? `"${w1}${value}${w2}"${p}` : null
-    let args = ['', valueArg, ...(vnode.props.args || [])].filter(x => x != null).join(', ')
+    let args = [direction ? '' : null, valueArg, ...(vnode.props.args || [])].filter(x => x != null).join(', ')
 
     return `\\arrow[${direction}${args}]`
 }


### PR DESCRIPTION
Without this change, an arrow without a direction and with attributes has a leading comma (e.g. `\arrow[, loop]`). This is currently not possible with tikzcd-editor, but will be with the advent of loops.